### PR TITLE
fix: pomodoro timer reset bug after session completion

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1959,6 +1959,12 @@ class _TrackerHomePageState extends State<TrackerHomePage> {
           timer.cancel();
           isPomodoroRunning = false;
           task.pomodoroCount++;
+
+          // Properly reset timer state
+          pomodoroTimer = null;
+          currentPomodoroTask = null;
+          pomodoroMinutesLeft = 25; // Reset to default
+
           _showPomodoroComplete();
           _saveData();
         }
@@ -1971,8 +1977,14 @@ class _TrackerHomePageState extends State<TrackerHomePage> {
     setState(() {
       isPomodoroRunning = false;
       currentPomodoroTask = null;
-      pomodoroMinutesLeft = 25;
+      pomodoroMinutesLeft = 25; // Reset to initial 25 minutes
     });
+
+    // Ensure timer is fully disposed
+    pomodoroTimer = null;
+
+    // Save state to prevent inconsistencies
+    _saveData();
   }
 
   Future<void> _showPomodoroComplete() async {


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where the pomodoro timer was not resetting properly after completing a session, causing subsequent sessions to start at incorrect times.

## Problem
The focus timer did not reset its state variables after a pomodoro session completed, leading to:
- Timer starting at wrong values in subsequent sessions
- Potential memory leaks from unreleased timer references
- Inconsistent application state
- User confusion when starting new pomodoro sessions

## Solution
Added proper state cleanup in the timer completion handler to ensure all timer-related variables are reset to their default values.

## Changes Made

**File Modified**: `lib/main.dart` (lines ~1145-1170)

### Code Changes
```dart
// Inside _startPomodoro method's Timer.periodic callback
setState(() {
  pomodoroMinutesLeft--;
  if (pomodoroMinutesLeft <= 0) {
    timer.cancel();
    isPomodoroRunning = false;
    task.pomodoroCount++;
    
    // Properly reset timer state
    pomodoroTimer = null;
    currentPomodoroTask = null;
    pomodoroMinutesLeft = 25; // Reset to default
    
    _showPomodoroComplete();
    _saveData();
  }
});
```

### Specific Fixes
- Reset `pomodoroMinutesLeft` to 25 after completion
- Set `pomodoroTimer` to null to prevent memory leaks
- Clear `currentPomodoroTask` reference for clean state
- Ensure `_saveData()` persists the correct state

## Testing Performed
- [x] Manually tested timer start/stop/complete cycles
- [x] Verified timer resets to 25 minutes after each session
- [x] Confirmed state variables are properly cleared
- [x] Tested multiple consecutive timer sessions
- [x] Verified no regression in existing timer functionality
- [x] Tested timer cancellation with stop button
- [x] Confirmed no memory leaks or orphaned timer references

## Expected Outcome
- Timer correctly resets to 25 minutes after each completed session
- No unexpected behavior when starting new sessions
- Clean state management without memory leaks
- Consistent user experience across multiple pomodoro sessions

## Impact
- Eliminates timer inconsistency bug
- Prevents user confusion from incorrect timer behavior
- Improves application reliability
- Prevents potential memory leaks
- Ensures predictable timer behavior

## Breaking Changes
None. This is a bug fix that maintains backward compatibility.

## Related Issues
Closes #1

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code changes
- [x] No new warnings introduced
- [x] Existing functionality preserved
- [x] Manual testing completed successfully
- [x] Bug is reproducible and fix has been verified
- [x] Commit message follows conventional commit format